### PR TITLE
Option to show/hide points + tweaks for health bar options visibility

### DIFF
--- a/src/Speedrun.cpp
+++ b/src/Speedrun.cpp
@@ -30,14 +30,23 @@ void Speedrun::on_draw_ui() {
     locked->draw("Lock Window");
     in_game_time->draw("In Game Time");
     game_rank->draw("Game Rank");
+
+    if (game_rank->value()) {
+        points->draw("Action and Item Points");
+    }
+
     money->draw("Money");
     spinels->draw("Spinels");
     local_enemies->draw("Nearby Enemies");
+
+    if (local_enemies->value()) {
+        boss_only->draw("Boss Health Only");
+    }
+
     kill_count->draw("Kill Count");
     companion->draw("Companion Distance");
-    boss_only->draw("Boss Health Only");
 
-    if (!boss_only->value()) {
+    if (local_enemies->value() && !boss_only->value()) {
         num_display->draw("Enemies to Display");
         ImGui::Text("Use 0 to display all enemies");
     }
@@ -110,7 +119,7 @@ void Speedrun::draw_stats() {
             continue;
         case 4:
             if (game_rank->value()) {
-                draw_game_rank();
+                draw_game_rank(points->value());
             }
             continue;
         case 5:
@@ -195,15 +204,17 @@ void Speedrun::draw_ingame_time() {
     }
 }
 
-void Speedrun::draw_game_rank() {
+void Speedrun::draw_game_rank(const bool show_points) {
     const auto rank_manager = API::get()->get_managed_singleton(game_namespace("GameRankSystem"));
     if (rank_manager != nullptr) {
         const auto current_rank = rank_manager->get_field<uint32_t>("_GameRank");
-        const auto action_point = rank_manager->get_field<float>("_ActionPoint");
-        const auto item_point = rank_manager->get_field<float>("_ItemPoint");
         ImGui::LabelText("Current Rank", "%i", *current_rank);
-        ImGui::LabelText("Action Point", "%f", *action_point);
-        ImGui::LabelText("Item Point", "%f", *item_point);
+        if (show_points) {
+            const auto action_point = rank_manager->get_field<float>("_ActionPoint");
+            const auto item_point = rank_manager->get_field<float>("_ItemPoint");
+            ImGui::LabelText("Action Points", "%f", *action_point);
+            ImGui::LabelText("Item Points", "%f", *item_point);
+        }
     }
 }
 

--- a/src/Speedrun.h
+++ b/src/Speedrun.h
@@ -21,7 +21,7 @@ public:
 
     static void draw_ingame_time();
 
-    static void draw_game_rank();
+    static void draw_game_rank(bool show_points);
 
     static void draw_enemies(int num_to_display, bool boss_only);
 
@@ -73,6 +73,7 @@ public:
         enabled->config_load(cfg);
         in_game_time->config_load(cfg);
         game_rank->config_load(cfg);
+        points->config_load(cfg);
         money->config_load(cfg);
         spinels->config_load(cfg);
         local_enemies->config_load(cfg);
@@ -91,6 +92,7 @@ public:
         enabled->config_save(cfg);
         in_game_time->config_save(cfg);
         game_rank->config_save(cfg);
+        points->config_save(cfg);
         money->config_save(cfg);
         spinels->config_save(cfg);
         local_enemies->config_save(cfg);
@@ -146,6 +148,7 @@ private:
     const ModToggle::Ptr enabled{ModToggle::create(generate_name("Enabled"), true)};
     const ModToggle::Ptr in_game_time{ModToggle::create(generate_name("In Game Time"), true)};
     const ModToggle::Ptr game_rank{ModToggle::create(generate_name("Rank"), true)};
+    const ModToggle::Ptr points{ModToggle::create(generate_name("Points"), true)};
     const ModToggle::Ptr money{ModToggle::create(generate_name("Money"), true)};
     const ModToggle::Ptr spinels{ModToggle::create(generate_name("Spinels"), true)};
     const ModToggle::Ptr local_enemies{ModToggle::create(generate_name("Local Enemies"), true)};


### PR DESCRIPTION
This PR adds an "Action and Item Points" option (enabled by default), to show/hide action and item points while keeping the rank. For people only interested in seeing the rank.
I kept the points tied to the rank however, so the option is only visible when "Game Rank" is enabled.

Also, to avoid confusion in the health bar options, I made the following changes:

* The "Boss Health Only" option is now only visible when "Nearby Enemies" is enabled. I saw a few users on Discord getting confused with this one, thinking the option would work on its own.
* The "Enemies to Display" option is now only visible when "Nearby Enemies" is enabled and "Boss Health Only" is disabled.

As usual I hope this is OK! As I said previously I'm still a C++ noob, so if there's a better of handling this (or if you just don't like these changes :p) don't feel bad about rejecting the PR!